### PR TITLE
fix: 評価でwinnerがnullの場合の表示・処理を修正

### DIFF
--- a/app/Services/Record/FilterManager.php
+++ b/app/Services/Record/FilterManager.php
@@ -144,10 +144,10 @@ class FilterManager
 
         $query->where(function ($q) use ($user, $winnerCondition, $loserCondition) {
             $q->where(function ($subQ) use ($user, $winnerCondition) {
-                $subQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $winnerCondition))
+                $subQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $winnerCondition)->whereNotNull('winner'))
                     ->where('affirmative_user_id', $user->id);
             })->orWhere(function ($subQ) use ($user, $loserCondition) {
-                $subQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $loserCondition))
+                $subQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $loserCondition)->whereNotNull('winner'))
                     ->where('negative_user_id', $user->id);
             });
         });
@@ -168,20 +168,20 @@ class FilterManager
             // 自分のディベート結果
             $q->where(function ($subQ) use ($user, $winnerCondition, $loserCondition) {
                 $subQ->where(function ($winQ) use ($user, $winnerCondition) {
-                    $winQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $winnerCondition))
+                    $winQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $winnerCondition)->whereNotNull('winner'))
                         ->where('affirmative_user_id', $user->id);
                 })->orWhere(function ($winQ) use ($user, $loserCondition) {
-                    $winQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $loserCondition))
+                    $winQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $loserCondition)->whereNotNull('winner'))
                         ->where('negative_user_id', $user->id);
                 });
             })
                 // デモディベート結果
                 ->orWhere(function ($subQ) use ($demoUserIds, $winnerCondition, $loserCondition) {
                     $subQ->where(function ($winQ) use ($demoUserIds, $winnerCondition) {
-                        $winQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $winnerCondition))
+                        $winQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $winnerCondition)->whereNotNull('winner'))
                             ->whereIn('affirmative_user_id', $demoUserIds);
                     })->orWhere(function ($winQ) use ($demoUserIds, $loserCondition) {
-                        $winQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $loserCondition))
+                        $winQ->whereHas('evaluations', fn($qe) => $qe->where('winner', $loserCondition)->whereNotNull('winner'))
                             ->whereIn('negative_user_id', $demoUserIds);
                     });
                 });

--- a/database/factories/DebateEvaluationFactory.php
+++ b/database/factories/DebateEvaluationFactory.php
@@ -160,6 +160,25 @@ class DebateEvaluationFactory extends Factory
     }
 
     /**
+     * Create an evaluation that is inconclusive (no winner).
+     */
+    public function inconclusive(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'winner' => null,
+            'reason' => 'The debate was inconclusive due to ' . fake()->randomElement([
+                'insufficient arguments from both sides.',
+                'equal strength of arguments making it impossible to determine a clear winner.',
+                'technical issues during the debate.',
+                'inappropriate content or behavior that prevented proper evaluation.'
+            ]),
+            'analysis' => 'This debate could not be properly evaluated. ' . fake()->paragraph(),
+            'feedback_for_affirmative' => 'Due to the inconclusive nature of this debate, specific feedback cannot be provided.',
+            'feedback_for_negative' => 'Due to the inconclusive nature of this debate, specific feedback cannot be provided.',
+        ]);
+    }
+
+    /**
      * Create an evaluation with technical feedback.
      */
     public function withTechnicalFeedback(): static

--- a/lang/en/records.php
+++ b/lang/en/records.php
@@ -53,4 +53,6 @@ return [
     'demo_mode_notice' => 'Viewing in Guest Mode',
     'demo_mode_description' => 'Topics starting with "Demo:" are sample debate records. Guest users can also participate in actual debates.',
     'result' => 'Result',
+    'evaluation_inconclusive' => 'Evaluation Inconclusive',
+    'evaluation_inconclusive_short' => 'Inconclusive',
 ];

--- a/lang/ja/records.php
+++ b/lang/ja/records.php
@@ -53,4 +53,6 @@ return [
     'demo_mode_notice' => 'ゲストモードで閲覧中',
     'demo_mode_description' => 'デモ:で始まる論題はサンプルのディベート履歴です。ゲストユーザーでも実際のディベートに参加できます。',
     'result' => '結果',
+    'evaluation_inconclusive' => '評価不能',
+    'evaluation_inconclusive_short' => '判定不能',
 ];

--- a/resources/views/debate/result.blade.php
+++ b/resources/views/debate/result.blade.php
@@ -154,6 +154,13 @@
                                                 {{ $evaluations->winner === 'affirmative' ? __('debates_ui.affirmative_side_label') : __('debates_ui.negative_side_label') }}
                                             </p>
                                         </div>
+                                        @else
+                                        <div class="bg-gray-50 p-3 sm:p-4 rounded-lg mt-3 sm:mt-4 flex items-center shadow-sm border border-gray-200">
+                                            <div class="flex items-center w-full">
+                                                <span class="material-icons-outlined text-gray-500 mr-2 text-sm sm:text-base">help_outline</span>
+                                                <p class="font-medium text-sm sm:text-base text-gray-600">{{ __('records.evaluation_inconclusive') }}</p>
+                                            </div>
+                                        </div>
                                         @endif
                                     </div>
                                 </div>

--- a/resources/views/records/partials/debate-card.blade.php
+++ b/resources/views/records/partials/debate-card.blade.php
@@ -18,16 +18,25 @@
     }
 
     // 勝敗判定
-    $isWinner = ($debate->evaluations->winner === 'affirmative' && $isAffirmative) ||
-               ($debate->evaluations->winner === 'negative' && !$isAffirmative);
+    if (!$debate->evaluations->winner) {
+        // 評価不能の場合
+        $isWinner = null;
+        $resultClass = 'bg-gray-100 text-gray-700 border-gray-300';
+        $resultText = __('records.evaluation_inconclusive_short');
+        $resultIcon = '<svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 sm:h-4 sm:w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>';
+    } else {
+        // 通常の勝敗判定
+        $isWinner = ($debate->evaluations->winner === 'affirmative' && $isAffirmative) ||
+                   ($debate->evaluations->winner === 'negative' && !$isAffirmative);
 
-    $resultClass = $isWinner
-        ? 'bg-success-light text-success border-success/30'
-        : 'bg-danger-light text-danger border-danger/30';
-    $resultText = $isWinner ? __('records.win') : __('records.loss');
-    $resultIcon = $isWinner
-        ? '<svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 sm:h-4 sm:w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>'
-        : '<svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 sm:h-4 sm:w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>';
+        $resultClass = $isWinner
+            ? 'bg-success-light text-success border-success/30'
+            : 'bg-danger-light text-danger border-danger/30';
+        $resultText = $isWinner ? __('records.win') : __('records.loss');
+        $resultIcon = $isWinner
+            ? '<svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 sm:h-4 sm:w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>'
+            : '<svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 sm:h-4 sm:w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>';
+    }
 
     $side = $isAffirmative ? __('rooms.affirmative_side') : __('rooms.negative_side');
     $sideClass = $isAffirmative ? 'text-success' : 'text-danger';

--- a/resources/views/records/show.blade.php
+++ b/resources/views/records/show.blade.php
@@ -148,6 +148,13 @@
                                                 {{ $evaluations->winner === 'affirmative' ? __('debates_ui.affirmative_side_label') : __('debates_ui.negative_side_label') }}
                                             </p>
                                         </div>
+                                        @else
+                                        <div class="bg-gray-50 p-3 sm:p-4 rounded-lg mt-3 sm:mt-4 flex items-center shadow-sm border border-gray-200">
+                                            <div class="flex items-center w-full">
+                                                <span class="material-icons-outlined text-gray-500 mr-2 text-sm sm:text-base">help_outline</span>
+                                                <p class="font-medium text-sm sm:text-base text-gray-600">{{ __('records.evaluation_inconclusive') }}</p>
+                                            </div>
+                                        </div>
                                         @endif
                                     </div>
                                 </div>

--- a/tests/Unit/Models/DebateEvaluationTest.php
+++ b/tests/Unit/Models/DebateEvaluationTest.php
@@ -241,6 +241,18 @@ class DebateEvaluationTest extends TestCase
         $this->assertStringContainsString('clear', strtolower($evaluation->analysis));
     }
 
+    #[Test]
+    public function test_factory_inconclusive()
+    {
+        $evaluation = DebateEvaluation::factory()->inconclusive()->create();
+
+        $this->assertNull($evaluation->winner);
+        $this->assertStringContainsString('inconclusive', strtolower($evaluation->reason));
+        $this->assertStringContainsString('could not be properly evaluated', strtolower($evaluation->analysis));
+        $this->assertStringContainsString('inconclusive nature', strtolower($evaluation->feedback_for_affirmative));
+        $this->assertStringContainsString('inconclusive nature', strtolower($evaluation->feedback_for_negative));
+    }
+
     /**
      * Integration tests
      */

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig({
                 'resources/js/pages/room-create.js',
                 'resources/js/pages/ai-debate-create.js',
                 'resources/js/pages/records-index.js',
+                'resources/js/pages/records-show.js',
             ],
             refresh: true,
         }),


### PR DESCRIPTION
## 概要
評価において、勝者（winner）が決定されていない（null）場合の表示と処理を改善しました。

## 修正内容

### 🔧 修正項目
- **勝者未決定時の表示対応**: 勝者が決まっていない討論結果の適切な表示
- **フィルタリング機能の改善**: FilterManagerでのnull値処理の修正
- **多言語対応**: 勝者未決定時のメッセージを日本語・英語で追加
- **UI表示の改善**: 各ビューでの適切な条件分岐による表示制御

### 📁 変更ファイル
- `app/Services/Record/FilterManager.php` - フィルタリング処理の修正
- `resources/views/debate/result.blade.php` - 結果表示ページの改善
- `resources/views/records/partials/debate-card.blade.php` - 討論カード表示の修正
- `resources/views/records/show.blade.php` - 詳細表示ページの改善
- `lang/ja/records.php`, `lang/en/records.php` - 多言語メッセージの追加
- `database/factories/DebateEvaluationFactory.php` - テスト用ファクトリーの拡張
- `tests/Unit/Models/DebateEvaluationTest.php` - 単体テストの追加

## その他
- `vite.config.js`の小さな設定修正も含まれています