### PR TITLE
fix: EchoとLivewireの初期化競合を解消し参加者表示を安定化

### DIFF
--- a/resources/views/livewire/debates/participants.blade.php
+++ b/resources/views/livewire/debates/participants.blade.php
@@ -89,9 +89,6 @@
 
     <!-- ターン終了ボタン -->
     <div class="mt-auto">
-        <!-- 早期終了コンポーネント -->
-        {{-- <livewire:debates.early-termination :debate="$debate" /> --}}
-
         @if($isMyTurn)
         <button wire:click="advanceTurnManually"
             wire:confirm="{{ __('debates_ui.confirm_end_turn', ['currentTurnName' => $currentTurnName, 'nextTurnName' => $nextTurnName]) }}"


### PR DESCRIPTION
## 概要

ディベートページのリアルタイム参加者表示機能を安定させるための修正です。
ページの読み込みタイミングによって発生していた、参加者のオンライン状態が正しく反映されない問題を解決しました。

## 背景・課題

これまで、ディベートページでは以下の課題がありました。

-   **問題点**:
    Laravel Echo（Pusher）のpresenceチャンネル初期化と、LivewireコンポーネントのDOM初期化は、どちらも非同期で行われます。このため、Echoが参加者リストを取得する`here()`イベントが発火した時点で、Livewireコンポーネントがまだイベントを受け取る準備ができていない、という競合状態が発生することがありました。

-   **影響**:
    この競合により、ページを読み込んだ直後に参加者リストが空になったり、一部のユーザーしか表示されなかったりといった、不安定な動作を引き起こしていました。

このプルリクエストは、これらの非同期処理のライフサイクルを同期させることで、リアルタイム機能の信頼性を確保することを目的としています。

## 解決策

以下の変更を加え、初期化処理の競合を解消しました。

1.  **堅牢な待機処理の導入 (`DebateEventHandler.js`)**
    -   Pusherの接続が `connected` になること、およびLivewireコンポーネントが利用可能になること、**両方の条件が満たされるまで** `Echo.join()` の実行を待機するロジックを実装しました。
    -   予期せぬ事態で初期化が滞らないよう、適切なタイムアウト処理も設けています。

2.  **初期化フローの改善 (`debate-show.js`)**
    -   ページ全体のJavaScript初期化処理（`DebateShowManager`）が、Pusherの接続確立後に開始されるようにフローを修正しました。
    -   `DebateEventHandler`がLivewireの状態をより確実に検知できるよう、Livewireコンポーネントの準備完了を知らせるカスタムイベント (`livewire:components-ready`) を発火させる仕組みを追加しました。