### PR TITLE
feat(debate): Alpine.jsを用いたJS初期化によるディベートページの安定化

### DIFF
--- a/resources/js/features/debate/event-handler.js
+++ b/resources/js/features/debate/event-handler.js
@@ -12,117 +12,13 @@ class DebateEventHandler {
         this.debateId = debateId;
         this.presenceChannel = null;
         this.offlineTimeout = null;
-        this.pendingInitialMembers = null;
-        this.isInitialized = false;
-        // presenceチャンネルの初期化はLivewireコンポーネントの準備完了後に実行
-        this.delayedInitialize();
-    }
-
-    /**
-     * 遅延初期化 - Pusher接続とLivewireコンポーネントの準備完了まで待機
-     */
-    delayedInitialize() {
-        // 両方の条件が満たされるまで待機
-        this.waitForInitializationConditions();
-    }
-
-    /**
-     * 初期化条件を満たすまで待機
-     */
-    waitForInitializationConditions() {
-        const checkConditions = () => {
-            const pusherReady = this.isPusherReady();
-            const livewireReady = window.Livewire && this.areLivewireComponentsReady();
-
-            this.logger.log('初期化条件チェック:', { pusherReady, livewireReady });
-
-            if (pusherReady && livewireReady) {
-                this.logger.log(
-                    'すべての初期化条件が満たされました。presenceチャンネルを初期化します。'
-                );
-                this.initEchoListeners();
-                return true;
-            }
-            return false;
-        };
-
-        // 即座にチェック
-        if (checkConditions()) {
-            return;
-        }
-
-        // Livewireコンポーネントの準備完了イベントを監視
-        document.addEventListener('livewire:components-ready', () => {
-            if (!this.isInitialized) {
-                this.logger.log('Livewireコンポーネントの準備完了イベントを受信しました。');
-                setTimeout(() => checkConditions(), 100);
-            }
-        });
-
-        // 定期的にチェック
-        const checkInterval = setInterval(() => {
-            if (checkConditions()) {
-                clearInterval(checkInterval);
-            }
-        }, 200);
-
-        // 最大15秒でタイムアウト（より長めに設定）
-        setTimeout(() => {
-            clearInterval(checkInterval);
-            if (!this.isInitialized) {
-                this.logger.warn(
-                    '初期化条件の待機中にタイムアウトしました。強制的に初期化します。'
-                );
-                this.initEchoListeners();
-            }
-        }, 15000);
-    }
-
-    /**
-     * Pusher接続の準備状況を確認
-     */
-    isPusherReady() {
-        if (!window.Echo) {
-            return false;
-        }
-
-        // EchoのPusherインスタンスの接続状態を確認
-        const pusher = window.Echo.connector.pusher;
-        if (!pusher) {
-            return false;
-        }
-
-        // 接続状態を確認（connected または connecting でも可）
-        const state = pusher.connection.state;
-        const isReady = state === 'connected' || state === 'connecting';
-
-        this.logger.log('Pusher接続状態:', state, 'Ready:', isReady);
-        return isReady;
-    }
-
-    /**
-     * Livewireコンポーネントの準備状況を確認
-     */
-    areLivewireComponentsReady() {
-        // Participants コンポーネントの存在確認
-        const participantsElement = document.querySelector('[wire\\:id]');
-        if (!participantsElement) {
-            return false;
-        }
-
-        const componentId = participantsElement.getAttribute('wire:id');
-        const component = window.Livewire.find(componentId);
-        return component !== null;
+        this.initEchoListeners();
     }
 
     /**
      * Echo リスナーを初期化
      */
     initEchoListeners() {
-        if (this.isInitialized) {
-            return;
-        }
-
         if (!window.Echo || !this.debateId) {
             this.logger.error('Echo または debateId が設定されていません');
             return;
@@ -131,86 +27,27 @@ class DebateEventHandler {
         this.presenceChannel = window.Echo.join(`debate.${this.debateId}`)
             .here(users => {
                 this.logger.log('Initial members:', users);
-                this.handleInitialMembers(users);
+                users.forEach(user => Livewire.dispatch('member-online', { data: user }));
             })
             .joining(user => {
                 this.logger.log(`${user.name} さんが再接続しました`);
                 clearTimeout(this.offlineTimeout);
-                this.dispatchMemberOnline(user);
+                Livewire.dispatch('member-online', { data: user });
             })
             .leaving(user => {
                 this.logger.log(`${user.name} さんが切断されました`);
                 clearTimeout(this.offlineTimeout);
                 this.offlineTimeout = setTimeout(() => {
-                    this.dispatchMemberOffline(user);
+                    Livewire.dispatch('member-offline', { data: user });
                 }, 3000);
             })
             .listen('DebateFinished', e => this.handleDebateFinished(e))
             .listen('DebateEvaluated', e => this.handleDebateEvaluated(e))
             .listen('DebateTerminated', e => this.handleDebateTerminated(e))
             .listen('EarlyTerminationExpired', e => this.handleEarlyTerminationExpired(e));
-
-        this.isInitialized = true;
     }
 
-    /**
-     * 初期メンバーを処理
-     */
-    handleInitialMembers(users) {
-        if (this.areLivewireComponentsReady()) {
-            users.forEach(user => this.dispatchMemberOnline(user));
-        } else {
-            // Livewireコンポーネントが準備されていない場合は一時保存
-            this.pendingInitialMembers = users;
-            this.waitForLivewireAndProcessInitialMembers();
-        }
-    }
-
-    /**
-     * Livewireコンポーネントの準備完了を待って初期メンバーを処理
-     */
-    waitForLivewireAndProcessInitialMembers() {
-        const checkInterval = setInterval(() => {
-            if (this.areLivewireComponentsReady()) {
-                clearInterval(checkInterval);
-                if (this.pendingInitialMembers) {
-                    this.pendingInitialMembers.forEach(user => this.dispatchMemberOnline(user));
-                    this.pendingInitialMembers = null;
-                }
-            }
-        }, 100);
-
-        // 最大5秒でタイムアウト
-        setTimeout(() => {
-            clearInterval(checkInterval);
-            if (this.pendingInitialMembers) {
-                this.logger.warn(
-                    'Livewireコンポーネントの準備完了を待機中にタイムアウトしました。初期メンバーを破棄します。'
-                );
-                this.pendingInitialMembers = null;
-            }
-        }, 5000);
-    }
-
-    /**
-     * member-onlineイベントを確実に送信
-     */
-    dispatchMemberOnline(user) {
-        if (window.Livewire) {
-            Livewire.dispatch('member-online', { data: user });
-        }
-    }
-
-    /**
-     * member-offlineイベントを確実に送信
-     */
-    dispatchMemberOffline(user) {
-        if (window.Livewire) {
-            Livewire.dispatch('member-offline', { data: user });
-        }
-    }
-
-    handleDebateFinished() {
+    handleDebateFinished(event) {
         showNotification({
             title: window.translations?.debate_finished_title || 'ディベートが終了しました',
             message:
@@ -222,7 +59,7 @@ class DebateEventHandler {
         this.showFinishedOverlay();
     }
 
-    handleDebateEvaluated() {
+    handleDebateEvaluated(event) {
         showNotification({
             title: window.translations?.evaluation_complete_title || 'ディベート評価が完了しました',
             message: window.translations?.redirecting_to_results || '結果ページへ移動します',
@@ -235,7 +72,7 @@ class DebateEventHandler {
         }, 2000);
     }
 
-    handleDebateTerminated() {
+    handleDebateTerminated(event) {
         setTimeout(() => {
             alert(
                 window.translations?.host_left_terminated ||
@@ -245,7 +82,7 @@ class DebateEventHandler {
         }, 2000);
     }
 
-    handleEarlyTerminationExpired() {
+    handleEarlyTerminationExpired(event) {
         showNotification({
             title:
                 window.translations?.early_termination_expired_notification ||

--- a/resources/js/pages/debate-show.js
+++ b/resources/js/pages/debate-show.js
@@ -39,14 +39,12 @@ class DebateShowManager {
 
             // 各機能の初期化（エラーハンドリング付き）
             this.safeInitialize('Countdown', () => this.initializeCountdown());
+            this.safeInitialize('EventHandler', () => this.initializeEventHandler());
             this.safeInitialize('Heartbeat', () => this.initializeHeartbeat());
             this.safeInitialize('ChatScroll', () => this.initializeChatScroll());
             this.safeInitialize('UIManager', () => this.initializeUIManager());
             this.safeInitialize('AudioHandler', () => this.initializeAudioHandler());
             this.safeInitialize('InputArea', () => this.initializeInputArea());
-
-            // EventHandlerは最後に初期化（presenceチャンネルの初期化を遅延させるため）
-            this.safeInitialize('EventHandler', () => this.initializeEventHandler());
 
             // グローバル参照設定（後方互換性のため）
             this.setupGlobalReferences();
@@ -184,28 +182,14 @@ class DebateShowManager {
         // Livewire初期化後に実行
         if (window.Livewire) {
             this.initializeLivewireComponents();
-            // Livewireコンポーネントの初期化完了を通知
-            this.notifyLivewireComponentsReady();
         } else {
             document.addEventListener('livewire:initialized', () => {
                 // さらに少し遅延して確実にDOM要素が準備されるのを待つ
                 setTimeout(() => {
                     this.initializeLivewireComponents();
-                    // Livewireコンポーネントの初期化完了を通知
-                    this.notifyLivewireComponentsReady();
                 }, 500);
             });
         }
-    }
-
-    /**
-     * Livewireコンポーネントの初期化完了を通知
-     */
-    notifyLivewireComponentsReady() {
-        // カスタムイベントを発火してpresenceチャンネルの初期化を促進
-        // eslint-disable-next-line no-undef
-        const event = new CustomEvent('livewire:components-ready');
-        document.dispatchEvent(event);
     }
 
     /**
@@ -484,25 +468,11 @@ document.addEventListener('DOMContentLoaded', () => {
         globalDebateManager.cleanup();
     }
 
-    // Pusher接続の確立を待ってから初期化
-    const initializeWhenReady = () => {
-        if (window.Echo && window.Echo.connector && window.Echo.connector.pusher) {
-            const pusher = window.Echo.connector.pusher;
-            const state = pusher.connection.state;
-
-            if (state === 'connected' || state === 'connecting') {
-                globalDebateManager = new DebateShowManager();
-                globalDebateManager.initialize();
-                return;
-            }
-        }
-
-        // Pusher接続が確立されていない場合は少し待って再試行
-        setTimeout(initializeWhenReady, 100);
-    };
-
-    // 初期化を遅延実行（Pusher接続確立後）
-    setTimeout(initializeWhenReady, 500);
+    // 初期化を遅延実行
+    setTimeout(() => {
+        globalDebateManager = new DebateShowManager();
+        globalDebateManager.initialize();
+    }, 300);
 });
 
 // ページ離脱時のクリーンアップ

--- a/resources/views/livewire/debates/header.blade.php
+++ b/resources/views/livewire/debates/header.blade.php
@@ -1,88 +1,90 @@
-<header class="debate-header bg-white border-b border-gray-200 shadow-sm z-10">
-    <div class="mx-auto px-4 sm:px-6 lg:px-8 py-1">
-        <div class="flex flex-col md:flex-row md:items-center md:justify-between">
-            <!-- 左側: トピック情報 -->
-            <div class="mb-2 md:mb-0 flex items-center">
-                <!-- デスクトップ用ハンバーガーメニュー -->
-                <button id="desktop-hamburger-menu" class="hidden md:block text-gray-700 p-2 rounded-full hover:bg-gray-100">
-                    <span class="material-icons">menu</span>
-                </button>
+<header
+    class="flex-none bg-white border-b border-gray-200 p-4 shadow-sm z-30"
+    x-data
+    x-init="initializeDebatePage({ debateId: {{ $debate->id }} })"
+>
+    <div class="flex justify-between items-center">
+        <!-- 左側: ディベート情報 -->
+        <div class="flex items-center space-x-4">
+            <!-- デスクトップ用ハンバーガーメニュー -->
+            <button id="desktop-hamburger-menu" class="hidden md:block text-gray-700 p-2 rounded-full hover:bg-gray-100">
+                <span class="material-icons">menu</span>
+            </button>
 
-                <!-- PC表示時のルーム名とトピック -->
-                <div class="hidden lg:block ml-2">
-                    <h1 class="text-sm md:text-lg font-medium text-gray-800 truncate">{{ $debate->room->name }}</h1>
-                    <p class="text-md md:text-xl font-bold text-gray-900 mt-0 break-words">
-                        {{ $debate->room->topic }}
-                    </p>
-                </div>
+            <!-- PC表示時のルーム名とトピック -->
+            <div class="hidden lg:block ml-2">
+                <h1 class="text-sm md:text-lg font-medium text-gray-800 truncate">{{ $debate->room->name }}</h1>
+                <p class="text-md md:text-xl font-bold text-gray-900 mt-0 break-words">
+                    {{ $debate->room->topic }}
+                </p>
             </div>
+        </div>
 
-            <!-- 右側: ターン情報とタイマー -->
-            <div class="flex items-center space-x-2 sm:space-x-4">
-                <!-- モバイル用ハンバーガーメニュー -->
-                <button id="mobile-hamburger-menu" class="md:hidden mr-2 text-gray-700 p-2 rounded-full hover:bg-gray-100">
-                    <span class="material-icons">menu</span>
+        <!-- 右側: ターン情報とタイマー -->
+        <div class="flex items-center space-x-2 sm:space-x-4">
+            <!-- モバイル用ハンバーガーメニュー -->
+            <button id="mobile-hamburger-menu" class="md:hidden mr-2 text-gray-700 p-2 rounded-full hover:bg-gray-100">
+                <span class="material-icons">menu</span>
+            </button>
+
+            <!-- AIディベートの場合は退出ボタンを表示 -->
+            @if($debate->room->is_ai_debate)
+            <form action="{{ route('ai.debate.exit', $debate) }}" method="POST"
+                onSubmit="return confirm('{{ __('ai_debate.confirm_exit_ai_debate') }}');">
+                @csrf
+                <button type="submit"
+                    class="btn-danger flex items-center px-2 py-1 sm:px-3 sm:py-1.5 text-xs rounded-lg transition-all hover:scale-105">
+                    <span class="material-icons-outlined mr-1 text-sm">exit_to_app</span>
+                    {{ __('ai_debate.exit_debate') }}
                 </button>
+            </form>
+            @endif
 
-                <!-- AIディベートの場合は退出ボタンを表示 -->
-                @if($debate->room->is_ai_debate)
-                <form action="{{ route('ai.debate.exit', $debate) }}" method="POST"
-                    onSubmit="return confirm('{{ __('ai_debate.confirm_exit_ai_debate') }}');">
-                    @csrf
-                    <button type="submit"
-                        class="btn-danger flex items-center px-2 py-1 sm:px-3 sm:py-1.5 text-xs rounded-lg transition-all hover:scale-105">
-                        <span class="material-icons-outlined mr-1 text-sm">exit_to_app</span>
-                        {{ __('ai_debate.exit_debate') }}
-                    </button>
-                </form>
-                @endif
+            <!-- 全画面切替ボタン -->
+            <button id="fullscreen-toggle" class="text-gray-700 p-2 rounded-full hover:bg-gray-100">
+                <span class="material-icons fullscreen-icon">fullscreen</span>
+            </button>
 
-                <!-- 全画面切替ボタン -->
-                <button id="fullscreen-toggle" class="text-gray-700 p-2 rounded-full hover:bg-gray-100">
-                    <span class="material-icons fullscreen-icon">fullscreen</span>
-                </button>
-
-                <!-- 現在のターン表示 -->
-                <div class="flex flex-col items-center text-center">
-                    <div class="px-3 py-1 rounded-full text-sm font-medium flex items-center {{
-                        $isMyTurn ? 'bg-primary-light text-primary' : (
-                        $isAITurn ? 'bg-blue-100 text-blue-800' : 'bg-gray-100 text-gray-800'
-                        )
-                    }}">
-                        {{-- AIアイコン --}}
-                        @if($isAITurn)
-                            <span class="material-icons-outlined text-sm mr-1">smart_toy</span>
-                        @endif
-                        {{-- サイド表示 --}}
-                        <span>
-                            {{ $currentSpeaker === 'affirmative' ? __('debates_ui.affirmative_side_label') : ($currentSpeaker === 'negative' ? __('debates_ui.negative_side_label') : '') }}
-                        </span>
-                        {{-- ターン名 --}}
-                        <span class="ml-1">{{ $currentTurnName }}</span>
-                    </div>
-                    {{-- ターン状況テキスト --}}
-                    <span class="text-xs text-gray-500 mt-0.5">
-                        @if($isMyTurn)
-                            {{ __('debates_ui.your_turn') }}
-                        @elseif($isAITurn)
-                            {{ __('ai_debate.ai_turn') }}
-                        @elseif($isPrepTime)
-                            {{ __('debates_format.prep_time') }}
-                        @else
-                            {{ __('debates_ui.opponent_turn') }}
-                        @endif
+            <!-- 現在のターン表示 -->
+            <div class="flex flex-col items-center text-center">
+                <div class="px-3 py-1 rounded-full text-sm font-medium flex items-center {{
+                    $isMyTurn ? 'bg-primary-light text-primary' : (
+                    $isAITurn ? 'bg-blue-100 text-blue-800' : 'bg-gray-100 text-gray-800'
+                    )
+                }}">
+                    {{-- AIアイコン --}}
+                    @if($isAITurn)
+                        <span class="material-icons-outlined text-sm mr-1">smart_toy</span>
+                    @endif
+                    {{-- サイド表示 --}}
+                    <span>
+                        {{ $currentSpeaker === 'affirmative' ? __('debates_ui.affirmative_side_label') : ($currentSpeaker === 'negative' ? __('debates_ui.negative_side_label') : '') }}
                     </span>
+                    {{-- ターン名 --}}
+                    <span class="ml-1">{{ $currentTurnName }}</span>
                 </div>
-
-                <!-- タイマー -->
-                <div class="flex flex-col items-center">
-                    <div class="text-2xl font-bold tabular-nums
-                        " id="countdown-timer">
-                    </div>
-                    <span class="text-xs text-gray-500">{{ __('debates_ui.remaining_time') }}</span>
-                </div>
-
+                {{-- ターン状況テキスト --}}
+                <span class="text-xs text-gray-500 mt-0.5">
+                    @if($isMyTurn)
+                        {{ __('debates_ui.your_turn') }}
+                    @elseif($isAITurn)
+                        {{ __('ai_debate.ai_turn') }}
+                    @elseif($isPrepTime)
+                        {{ __('debates_format.prep_time') }}
+                    @else
+                        {{ __('debates_ui.opponent_turn') }}
+                    @endif
+                </span>
             </div>
+
+            <!-- タイマー -->
+            <div class="flex flex-col items-center">
+                <div class="text-2xl font-bold tabular-nums
+                    " id="countdown-timer">
+                </div>
+                <span class="text-xs text-gray-500">{{ __('debates_ui.remaining_time') }}</span>
+            </div>
+
         </div>
     </div>
 </header>

--- a/resources/views/livewire/debates/participants.blade.php
+++ b/resources/views/livewire/debates/participants.blade.php
@@ -89,6 +89,9 @@
 
     <!-- ターン終了ボタン -->
     <div class="mt-auto">
+        <!-- 早期終了コンポーネント -->
+        {{-- <livewire:debates.early-termination :debate="$debate" /> --}}
+
         @if($isMyTurn)
         <button wire:click="advanceTurnManually"
             wire:confirm="{{ __('debates_ui.confirm_end_turn', ['currentTurnName' => $currentTurnName, 'nextTurnName' => $nextTurnName]) }}"


### PR DESCRIPTION
#### 課題
従来のディベートページでは、JavaScriptの初期化処理を`DOMContentLoaded`や`livewire:initialized`イベントに依存していました。このアプローチは、Livewireの複雑なライフサイクルとの間で競合を発生させ、以下のような深刻なタイミング問題を引き起こしていました。

- **オンライン状態表示の不安定化**: WebSocket(`Echo`)の初期化が適切なタイミングで行われず、オンライン状態が正しく表示されないことが頻発していました。
- **ブロードキャストイベントの処理不全**: ターン進行やメッセージ受信などの重要なサーバーイベントが、フロントエンドで適切に処理されない問題がありました。
- **初期化時のTypeError**: Livewireの内部オブジェクトが未準備の段階でアクセスしようとして、スクリプトエラーが発生していました。

これらの問題は、特にブラウザリロード時やLivewireによるページ内遷移時に顕著であり、ユーザー体験を大きく損なっていました。

#### 解決策
このプルリクエストでは、上記の問題を根本的に解決するため、ディベートページのJavaScript初期化方法を全面的にリファクタリングしました。

**主な変更点:**

1.  **Alpine.jsによる初期化トリガー**:
    - 初期化の起点となる処理を、Livewireコンポーネント(`header.blade.php`)内の`x-init`ディレクティブに変更しました。
    - これにより、LivewireのDOMと内部状態が完全に準備完了した最適なタイミングで、安全にJavaScriptの初期化を実行できるようになりました。

2.  **信頼性の高い単一エントリーポイント**:
    - `debate-show.js`にグローバル関数`window.initializeDebatePage(data)`を新設し、初期化処理のエントリーポイントを一本化しました。
    - `setTimeout`のような不確実なタイミング調整を完全に排除し、信頼性を向上させています。

3.  **依存性の明確化**:
    - `debateId`などの必要なデータを、Bladeから`x-init`経由で直接JavaScript関数に引数として渡すように変更しました。
    - これにより、グローバルな`window.debateData`オブジェクトへの依存がなくなり、コードの見通しが良くなりました。

4.  **堅牢なクリーンアップ処理**:
    - `livewire:navigating`イベントをフックし、ページ遷移前に必ず`cleanup()`関数が呼ばれる仕組みを確立しました。
    - これにより、古い`Echo`のリスナーやタイマーが残存することなく確実に解放され、メモリリークやリスナーの重複登録を防ぎます。
