### PR TITLE
feat: サイトマップ機能追加とデベート関連の改善・修正

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Room;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Carbon\Carbon;
+
+class SitemapController extends Controller
+{
+    /**
+     * サイトマップXMLを生成して返す
+     */
+    public function index(): Response
+    {
+        // 静的ページのURL設定
+        $staticPages = [
+            [
+                'url' => route('welcome'),
+                'lastmod' => Carbon::now()->toISOString(),
+                'changefreq' => 'weekly',
+                'priority' => '1.0'
+            ],
+            [
+                'url' => route('guide'),
+                'lastmod' => Carbon::now()->toISOString(),
+                'changefreq' => 'monthly',
+                'priority' => '0.8'
+            ],
+            [
+                'url' => route('terms'),
+                'lastmod' => Carbon::now()->toISOString(),
+                'changefreq' => 'yearly',
+                'priority' => '0.3'
+            ],
+            [
+                'url' => route('privacy'),
+                'lastmod' => Carbon::now()->toISOString(),
+                'changefreq' => 'yearly',
+                'priority' => '0.3'
+            ],
+            [
+                'url' => route('contact.index'),
+                'lastmod' => Carbon::now()->toISOString(),
+                'changefreq' => 'monthly',
+                'priority' => '0.5'
+            ],
+            [
+                'url' => route('rooms.index'),
+                'lastmod' => Carbon::now()->toISOString(),
+                'changefreq' => 'hourly',
+                'priority' => '0.9'
+            ]
+        ];
+
+        // 動的ページ（ルーム）の取得
+        $rooms = Room::whereNotIn('status', ['deleted', 'terminated'])
+                     ->orderBy('updated_at', 'desc')
+                     ->get();
+
+        $roomPages = [];
+        foreach ($rooms as $room) {
+            $roomPages[] = [
+                'url' => route('rooms.preview', $room->id),
+                'lastmod' => $room->updated_at->toISOString(),
+                'changefreq' => 'daily',
+                'priority' => '0.7'
+            ];
+        }
+
+        $allPages = array_merge($staticPages, $roomPages);
+
+        return response()
+            ->view('sitemap', compact('allPages'))
+            ->header('Content-Type', 'text/xml');
+    }
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow:
+
+Sitemap: https://debate-match.com/sitemap.xml

--- a/resources/js/features/debate/audio-handler.js
+++ b/resources/js/features/debate/audio-handler.js
@@ -52,7 +52,7 @@ class AudioHandler {
         }
 
         // チャンネル参照を保存してクリーンアップ時に使用
-        this.debateChannel = window.Echo.private(`debate.${debateId}`);
+        this.debateChannel = window.Echo.join(`debate.${debateId}`);
 
         // 通知音機能の実装 - メッセージ受信時
         this.debateChannel.listen('DebateMessageSent', () => {
@@ -110,9 +110,8 @@ class AudioHandler {
     cleanup() {
         // Echoチャンネルのクリーンアップ
         if (this.debateChannel) {
-            this.debateChannel
-                .stopListening('DebateMessageSent')
-                .stopListening('TurnAdvanced');
+            this.debateChannel.stopListening('DebateMessageSent').stopListening('TurnAdvanced');
+            this.debateChannel.leave();
             this.debateChannel = null;
             this.logger.log(`Echo listeners removed from debate channel.`);
         }

--- a/resources/views/livewire/debates/message-input.blade.php
+++ b/resources/views/livewire/debates/message-input.blade.php
@@ -64,6 +64,7 @@
             <textarea
                 id="message-input"
                 wire:model.live="newMessage"
+                wire:ignore.self
                 placeholder="{{ ($isMyTurn || $isQuestioningTurn) && !$isPrepTime ? __('debates_ui.enter_message_placeholder') : __('debates_ui.cannot_send_message_now') }}"
                 class="flex-1 border rounded-lg px-4 py-2 focus:ring-primary focus:border-primary resize-none overflow-y-auto bg-white disabled:bg-gray-100"
                 maxlength="5000"

--- a/resources/views/sitemap.blade.php
+++ b/resources/views/sitemap.blade.php
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+@foreach ($allPages as $page)
+    <url>
+        <loc>{{ $page['url'] }}</loc>
+        <lastmod>{{ $page['lastmod'] }}</lastmod>
+        <changefreq>{{ $page['changefreq'] }}</changefreq>
+        <priority>{{ $page['priority'] }}</priority>
+    </url>
+@endforeach
+</urlset>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\Admin\ConnectionAnalyticsController;
 use App\Http\Controllers\LocaleController;
 use App\Http\Controllers\Auth\GoogleLoginController;
 use App\Http\Controllers\AIDebateController;
+use App\Http\Controllers\SitemapController;
 use Illuminate\Support\Facades\Broadcast;
 
 // 基本ルート
@@ -38,6 +39,9 @@ Route::middleware([CheckUserActiveStatus::class])->group(function () {
 
     // お問い合わせページ
     Route::get('/contact', [ContactController::class, 'index'])->name('contact.index');
+    
+    // サイトマップ
+    Route::get('/sitemap.xml', [SitemapController::class, 'index'])->name('sitemap');
 });
 
 Route::get('/dashboard', function () {


### PR DESCRIPTION
以下の機能追加と修正を行いました。

- **サイトマップ機能の追加**:
  - SEO改善のため、サイトマップXMLを生成し、`sitemap.xml`として公開しました。
  - 静的ページ（トップページ、ガイド、利用規約、プライバシーポリシー、お問い合わせ、ルーム一覧）と、公開されている動的ルームページのURLをサイトマップに含めています。
  - `robots.txt`にサイトマップのパスを追記し、検索エンジンのクロールを促進します。

- **DebateチャンネルのEcho購読とクリーンアップ処理の強化**:
  - `resources/js/features/debate/audio-handler.js`において、Echoのチャンネル購読を`private`から`join`（Presence Channel）に変更しました。
  - チャンネル離脱時（`cleanup`メソッド）に`this.debateChannel.leave()`を追加し、Echoリスナーとチャンネルのクリーンアップ処理をより確実に行うように改善しました。

- **Livewireのtextareaリサイズ競合防止**:
  - `resources/views/livewire/debates/message-input.blade.php`の`textarea`要素に`wire:ignore.self`ディレクティブを追加しました。
  - これにより、LivewireがDOMを再評価する際に、textareaの外部からのリサイズ操作とLivewireのDOM更新が競合するのを防ぎ、UIの安定性を向上させます。
